### PR TITLE
Ignore players in creative or spectator mode when applying effects

### DIFF
--- a/data/tater/functions/tick.mcfunction
+++ b/data/tater/functions/tick.mcfunction
@@ -1,10 +1,10 @@
 # Damage in water
-execute at @a run execute if block ~ ~ ~ minecraft:water run function tater:water_effect
+execute at @a[gamemode=!creative,gamemode=!spectator] run execute if block ~ ~ ~ minecraft:water run function tater:water_effect
 # Damage in cauldron
-execute at @a run execute if block ~ ~ ~ minecraft:water_cauldron run function tater:water_effect
+execute at @a[gamemode=!creative,gamemode=!spectator] run execute if block ~ ~ ~ minecraft:water_cauldron run function tater:water_effect
 
 # Destroy boats
 execute at @e[type=minecraft:boat] run execute if block ~ ~ ~ minecraft:water run kill @e[type=minecraft:boat,distance=..1]
 
 # Damage rain // Always at the end bc recursive function
-execute as @a at @s if predicate tater:rain run function tater:detecting_rain
+execute as @a[gamemode=!creative,gamemode=!spectator] at @s if predicate tater:rain run function tater:detecting_rain

--- a/data/tater/functions/water_effect.mcfunction
+++ b/data/tater/functions/water_effect.mcfunction
@@ -1,2 +1,2 @@
-effect give @p minecraft:instant_damage 1
-effect give @p minecraft:resistance 2 2 true
+effect give @p[gamemode=!creative,gamemode=!spectator] minecraft:instant_damage 1
+effect give @p[gamemode=!creative,gamemode=!spectator] minecraft:resistance 2 2 true


### PR DESCRIPTION
As the title says, this fix will ignore players in creative or spectator mode when applying the instant damage effects.

Tested on 1.19.2 and it works as expected.